### PR TITLE
Add support for local AI server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode
+.python-version
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/)
 
 
-**Fork Note**: This fork comes with additional support for a Local API Server [**WebAI to API**](https://github.com/Amm1rr/WebAI-to-API/) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
+**Fork Note**: This fork comes with additional support for a Local API Server ([**WebAI to API**](https://github.com/Amm1rr/WebAI-to-API/)) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
 
 This is a research day project,
 Use at your responsibility.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Here's how to install and use ChatGPT Code Review on your local machine:
 
 Run **[WebAI to API](https://github.com/Amm1rr/WebAI-to-API/)** and then:
    ```bash
-   streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/v1/chat/completions/CodeReview
+   streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/v1/chat/completions
    ```
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/)
 
+
+**Fork Note**: This fork comes with additional support for a [**Local API Server**](https://github.com/Amm1rr/WebAI-to-API/) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
+
 [ChatGPT Code Review](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/) is an app designed to help software developers improve
 their code quality by leveraging the power of OpenAI's large language models.
 The app analyzes the code in a given GitHub repository and provides
@@ -32,6 +35,7 @@ Keep in mind that ChatGPT Code Review is an AI-powered tool, and while it can
 provide helpful insights, it may not always be perfect. It is essential to use
 your judgment and expertise when assessing the recommendations provided by the
 app.
+
 
 ## Example
 
@@ -82,3 +86,7 @@ Run **[Free Chatbot API](https://github.com/Amm1rr/Free-Chatbot-API/)** and then
    ```bash
    streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/v1/chat/completions/CodeReview
    ```
+<hr>
+
+[![](https://visitcount.itsvg.in/api?id=amm1rr&label=V&color=0&icon=2&pretty=true)](https://github.com/Amm1rr/)
+

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Here's how to install and use ChatGPT Code Review on your local machine:
 
 5. **Launch the app**: To get the app running, use this command:
 
+**OpenAI API**:
    ```bash
    streamlit run chatgpt_code_review/app.py
+   ```
+
+**Local Server**:
+
+Run **[Free Chatbot API](https://github.com/Amm1rr/Free-Chatbot-API/)** and then:
+   ```bash
+   streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/v1/chat/completions/CodeReview
    ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here's how to install and use ChatGPT Code Review on your local machine:
 
 **Local Server**:
 
-Run **[Free Chatbot API](https://github.com/Amm1rr/Free-Chatbot-API/)** and then:
+Run **[WebAI to API](https://github.com/Amm1rr/WebAI-to-API/)** and then:
    ```bash
    streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/v1/chat/completions/CodeReview
    ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **Fork Note**: This fork comes with additional support for a [**Local API Server**](https://github.com/Amm1rr/WebAI-to-API/) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
 
+Use at your responsibility.
+
 [ChatGPT Code Review](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/) is an app designed to help software developers improve
 their code quality by leveraging the power of OpenAI's large language models.
 The app analyzes the code in a given GitHub repository and provides

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 **Fork Note**: This fork comes with additional support for a [**Local API Server**](https://github.com/Amm1rr/WebAI-to-API/) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
 
+This is a research day project,
 Use at your responsibility.
+
 
 [ChatGPT Code Review](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/) is an app designed to help software developers improve
 their code quality by leveraging the power of OpenAI's large language models.
@@ -91,4 +93,3 @@ Run **[WebAI to API](https://github.com/Amm1rr/WebAI-to-API/)** and then:
 <hr>
 
 [![](https://visitcount.itsvg.in/api?id=amm1rr&label=V&color=0&icon=2&pretty=true)](https://github.com/Amm1rr/)
-

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# ChatGPT Code Review
+# Auto Code Review
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/)
 
 
-**Fork Note**: This fork comes with additional support for a [**Local API Server**](https://github.com/Amm1rr/WebAI-to-API/) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
+**Fork Note**: This fork comes with additional support for a Local API Server [**WebAI to API**](https://github.com/Amm1rr/WebAI-to-API/) for [ChatGPT](https://github.com/Amm1rr/WebAI-to-API/) and [Claude](https://github.com/Amm1rr/WebAI-to-API/) support.
 
 This is a research day project,
 Use at your responsibility.
 
 
-[ChatGPT Code Review](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/) is an app designed to help software developers improve
+[Auto Code Review](https://domvwt-chatgpt-code-review-chatgpt-code-reviewmain-cfe8uj.streamlit.app/) is an app designed to help software developers improve
 their code quality by leveraging the power of OpenAI's large language models.
 The app analyzes the code in a given GitHub repository and provides
 recommendations to enhance the code. It is a valuable tool for developers,
 allowing them to discover potential issues in their codebase.
 
-To use ChatGPT Code Review and get recommendations for your code, follow these
+To use Auto Code Review and get recommendations for your code, follow these
 steps:
 
-1. **Access the app**: Open the ChatGPT Code Review app in your web browser.
+1. **Access the app**: Open the Auto Code Review app in your web browser.
 2. **Enter the GitHub repository URL**: In the input field labeled "GitHub
    Repository URL", enter the URL of the repository you'd like to analyze.
 3. **Enter your OpenAI API Key**: In the input field labeled "OpenAI API Key",
@@ -35,7 +35,7 @@ steps:
    Review these recommendations to identify potential areas for improvement in
    your code.
 
-Keep in mind that ChatGPT Code Review is an AI-powered tool, and while it can
+Keep in mind that Auto Code Review is an AI-powered tool, and while it can
 provide helpful insights, it may not always be perfect. It is essential to use
 your judgment and expertise when assessing the recommendations provided by the
 app.
@@ -49,7 +49,7 @@ app.
 
 ## Installation and Usage
 
-Here's how to install and use ChatGPT Code Review on your local machine:
+Here's how to install and use Auto Code Review on your local machine:
 
 1. **Clone the repository**: Execute this on your local machine and navigate to the project directory:
 
@@ -81,6 +81,7 @@ Here's how to install and use ChatGPT Code Review on your local machine:
 
 **OpenAI API**:
    ```bash
+   # ChatGPT
    streamlit run chatgpt_code_review/app.py
    ```
 
@@ -88,7 +89,11 @@ Here's how to install and use ChatGPT Code Review on your local machine:
 
 Run **[WebAI to API](https://github.com/Amm1rr/WebAI-to-API/)** and then:
    ```bash
+   # ChatGPT
    streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/v1/chat/completions
+   
+   # Claude
+   streamlit run chatgpt_code_review/app.py SERVER http://127.0.0.1:8000/claude/v1/chat/completions
    ```
 <hr>
 

--- a/chatgpt_code_review/forms.py
+++ b/chatgpt_code_review/forms.py
@@ -13,10 +13,11 @@ class RepoForm:
 
     options = EXTENSION_TO_LANGUAGE_MAP.keys()
 
-    def __init__(self, default_repo_url: str):
+    def __init__(self, default_repo_url: str, localserver: str = None):
         self.default_repo_url = default_repo_url
         self.repo_url = ""
         self.api_key = ""
+        self.localserver=localserver
         self.extensions = []
         self.additional_extensions = ""
 
@@ -26,12 +27,22 @@ class RepoForm:
             "GitHub Repository URL:", self.default_repo_url
         )
 
-        env_api_key = os.getenv("OPENAI_API_KEY", "")
-        self.api_key = st.text_input(
-            "OpenAI API Key:",
-            env_api_key,
-            placeholder="Paste your API key here",
-        )
+
+        if self.localserver:
+            env_api_key = ": )"
+            self.api_key = st.text_input(
+                "OpenAI Local Server:",
+                env_api_key,
+                placeholder=self.localserver,
+            )
+        else:
+            env_api_key = os.getenv("OPENAI_API_KEY", "")
+            self.api_key = st.text_input(
+                "OpenAI API Key:",
+                env_api_key,
+                placeholder="Paste your API key here",
+            )
+
         openai.api_key = self.api_key
 
         self.extensions = st.multiselect(


### PR DESCRIPTION
Added local hosting support for the **[WebAI to API](https://github.com/amm1rr/WebAI-to-API/)**.

For those interested, it's possible to run the ChatGPT API for free locally using the **[WebAI to API](https://github.com/amm1rr/WebAI-to-API/)**. Simply launch your local web server and you're good to go.

Please refer to the instructions at the end of the **README.md** file for usage guidelines.

![Local Image](https://pbs.twimg.com/media/F3GNfqlX0AAemyy?format=jpg&name=large)
